### PR TITLE
Support for sending multiple URLs at once

### DIFF
--- a/examples/image-multi-url.php
+++ b/examples/image-multi-url.php
@@ -18,7 +18,7 @@ $responses = $kraken->multi_url($urls, $params);
 
 foreach($responses as $url => $data)
 {
-    if ($response["success"]) {
+    if ($data["success"]) {
         echo "Success for image " . $url . ". Optimized image URL: ". $data["kraked_url"];
     } else {
         echo "Failed for image " . $url . ". Error message: " . $data["error"];

--- a/examples/image-multi-url.php
+++ b/examples/image-multi-url.php
@@ -1,0 +1,28 @@
+<?php
+
+require_once("Kraken.php");
+
+$kraken = new Kraken("your-api-key", "your-api-secret");
+
+$urls = array(
+    "http://url-to-images/file1.jpg",
+    "http://url-to-images/file2.jpg",
+    "http://url-to-images/file3.jpg"
+);
+
+$params = array(
+    "wait" => true
+);
+
+$responses = $kraken->multi_url($urls, $params);
+
+foreach($responses as $url => $data)
+{
+    if ($response["success"]) {
+        echo "Success for image " . $url . ". Optimized image URL: ". $data["kraked_url"];
+    } else {
+        echo "Failed for image " . $url . ". Error message: " . $data["error"];
+    }
+}
+
+?>

--- a/lib/Kraken.php
+++ b/lib/Kraken.php
@@ -23,6 +23,12 @@ class Kraken
         return $response;
     }
 
+    private function json_decode_array($input)
+    {
+        $from_json = json_decode($input, true);
+        return $from_json ? $from_json : $input;
+    }
+
     public function multi_url($urls, $opts = array())
     {
         $multi_curl = curl_multi_init();
@@ -48,7 +54,7 @@ class Kraken
         }
         curl_multi_close($multi_curl);
 
-        return $responses;
+        return array_map(array('self', 'json_decode_array'), $responses);
     }
 
     public function upload($opts = array())


### PR DESCRIPTION
This branch adds support for sending multiple URLs to Kraken via a cURL multi handle, which can be significantly faster than making many individual cURL requests. The syntax to make a multiple url request is `$kraken->multi_url($array_of_urls, $options);`. The function returns the array of responses indexed by URL, e.g.

```
array(
    'url1' => array( // array of Kraken response data),
    'url2' => array( // array of Kraken response data),
    // ...
)
```
