### PR TITLE
cURL error handling

### DIFF
--- a/lib/Kraken.php
+++ b/lib/Kraken.php
@@ -87,6 +87,13 @@ class Kraken {
 
         $response = json_decode(curl_exec($curl), true);
 
+        if ($response === null) {
+            $response = array (
+                "success" => false,
+                "error" => 'cURL Error: ' . curl_error($curl)
+            );
+        }
+        
         curl_close($curl);
 
         return $response;


### PR DESCRIPTION
Was getting a null $response due to cURL SSL problems. (Not sure why GitHub removed the trailing newline).